### PR TITLE
feat(f15e): add F15E_Listener and update DeviceContext for F-15E UFC

### DIFF
--- a/DeviceContext.cs
+++ b/DeviceContext.cs
@@ -15,9 +15,9 @@ namespace WWCduDcsBiosBridge
         private readonly DcsBiosConfig? config;
         private readonly bool linkedBGbrightness;
 
-        public DeviceContext(ICdu mcdu, 
-            bool displayBottomAligned, 
-            bool displayCMS, 
+        public DeviceContext(ICdu mcdu,
+            bool displayBottomAligned,
+            bool displayCMS,
             bool linkedBGbrightness,
             DcsBiosConfig? config)
         {
@@ -37,7 +37,7 @@ namespace WWCduDcsBiosBridge
                 .White()
                 .LeftLabel(2, "A10C").RightLabel(2, "AH64D")
                 .LeftLabel(3, "FA18C").RightLabel(3, "CH-47 (PLT)")
-                .RightLabel(4, "CH-47 (CPLT)")
+                .LeftLabel(4, "F15E").RightLabel(4, "CH-47 (CPLT)")
                 .BottomLine().WriteLine("Menu key to exit");
             Mcdu.RefreshDisplay();
             Mcdu.KeyDown += ReadMenu;
@@ -51,6 +51,7 @@ namespace WWCduDcsBiosBridge
                 case Key.LineSelectRight2: SelectedAircraft = 46; break; // AH64D
                 case Key.LineSelectLeft3: SelectedAircraft = 20; break;  // FA18C
                 case Key.LineSelectRight3: SelectedAircraft = 50; Pilot = true; break; // CH-47 PLT
+                case Key.LineSelectLeft4: SelectedAircraft = 44; break;  // F15E
                 case Key.LineSelectRight4: SelectedAircraft = 50; Pilot = false; break; // CH-47 CPLT
                 case Key.Menu:
                 case Key.McduMenu:
@@ -72,7 +73,8 @@ namespace WWCduDcsBiosBridge
                 [5] = () => new A10C_Listener(Mcdu, displayBottomAligned, displayCMS),
                 [46] = () => new AH64D_Listener(Mcdu, displayBottomAligned),
                 [20] = () => new FA18C_Listener(Mcdu, displayBottomAligned),
-                [50] = () => new CH47F_Listener(Mcdu, linkedBGbrightness , Pilot)
+                [44] = () => new F15E_Listener(Mcdu, displayBottomAligned),
+                [50] = () => new CH47F_Listener(Mcdu, linkedBGbrightness, Pilot),
             };
 
             if (aircraftMap.TryGetValue(SelectedAircraft, out var factory))

--- a/F15E_Listener.cs
+++ b/F15E_Listener.cs
@@ -1,0 +1,70 @@
+﻿using DCS_BIOS.ControlLocator;
+using DCS_BIOS.EventArgs;
+using DCS_BIOS.Serialized;
+using McduDotNet;
+
+namespace WWCduDcsBiosBridge
+{
+    internal class F15E_Listener : AircraftListener
+    {
+        private DCSBIOSOutput? F_UFC_LINE1_DISPLAY;
+        private DCSBIOSOutput? F_UFC_LINE2_DISPLAY;
+        private DCSBIOSOutput? F_UFC_LINE3_DISPLAY;
+        private DCSBIOSOutput? F_UFC_LINE4_DISPLAY;
+        private DCSBIOSOutput? F_UFC_LINE5_DISPLAY;
+        private DCSBIOSOutput? F_UFC_LINE6_DISPLAY;
+
+        protected override string GetFontFile() => "resources/a10c-font-21x31.json";
+        protected override string GetAircraftName() => "F-15E";
+
+        const int _AircraftNumber = 44;
+
+        public F15E_Listener(ICdu mcdu, bool bottomAligned) : base(mcdu, _AircraftNumber, bottomAligned)
+        {
+        }
+
+        protected override void initBiosControls()
+        {
+            F_UFC_LINE1_DISPLAY = DCSBIOSControlLocator.GetStringDCSBIOSOutput("F_UFC_LINE1_DISPLAY");
+            F_UFC_LINE2_DISPLAY = DCSBIOSControlLocator.GetStringDCSBIOSOutput("F_UFC_LINE2_DISPLAY");
+            F_UFC_LINE3_DISPLAY = DCSBIOSControlLocator.GetStringDCSBIOSOutput("F_UFC_LINE3_DISPLAY");
+            F_UFC_LINE4_DISPLAY = DCSBIOSControlLocator.GetStringDCSBIOSOutput("F_UFC_LINE4_DISPLAY");
+            F_UFC_LINE5_DISPLAY = DCSBIOSControlLocator.GetStringDCSBIOSOutput("F_UFC_LINE5_DISPLAY");
+            F_UFC_LINE6_DISPLAY = DCSBIOSControlLocator.GetStringDCSBIOSOutput("F_UFC_LINE6_DISPLAY");
+        }
+
+        public override void DcsBiosDataReceived(object sender, DCSBIOSDataEventArgs e)
+        {
+            try
+            {
+                UpdateCounter(e.Address, e.Data);
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        public override void DCSBIOSStringReceived(object sender, DCSBIOSStringDataEventArgs e)
+        {
+            try
+            {
+                UpdateLine(mcdu.Output.Line(2).White(), F_UFC_LINE1_DISPLAY, e);
+                UpdateLine(mcdu.Output.Line(4).Red(), F_UFC_LINE2_DISPLAY, e);
+                UpdateLine(mcdu.Output.Line(6).Red(), F_UFC_LINE3_DISPLAY, e);
+                UpdateLine(mcdu.Output.Line(8).Red(), F_UFC_LINE4_DISPLAY, e);
+                UpdateLine(mcdu.Output.Line(10).White(), F_UFC_LINE5_DISPLAY, e);
+                UpdateLine(mcdu.Output.Line(12).White(), F_UFC_LINE6_DISPLAY, e);
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        private void UpdateLine(Compositor display, DCSBIOSOutput? output, DCSBIOSStringDataEventArgs e)
+        {
+            if (output == null || e.Address != output.Address) return;
+            string data = e.StringData;
+            display.Centered(data);
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds support for the F-15E aircraft to the device context and bridge system. The main changes include updating the startup screen and menu selection logic to include the F-15E, integrating a new listener class for the F-15E, and wiring up the necessary display and event handling logic.

**F-15E Aircraft Integration:**

* Added a new `F15E_Listener` class to handle DCS BIOS events and display updates for the F-15E aircraft (`F15E_Listener.cs`).
* Updated the startup screen in `DeviceContext.cs` to display the F-15E option and correctly label the aircraft selection menu (`ShowStartupScreen`).
* Modified the menu selection logic in `DeviceContext.cs` to allow users to select the F-15E aircraft (`ReadMenu`).
* Registered the F-15E listener in the aircraft map so the bridge can instantiate it when selected.