### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - '**' # Triggers on push to any branch
 
+permissions:
+  contents: read
+
 env:
   DOTNET_VERSION: '8.0.x'
   CONFIGURATION: 'Release'


### PR DESCRIPTION
Potential fix for [https://github.com/landre-cerp/WWCduDcsBiosBridge/security/code-scanning/1](https://github.com/landre-cerp/WWCduDcsBiosBridge/security/code-scanning/1)

To fix the problem, you should add an explicit `permissions` block that sets the least required privilege for the GITHUB_TOKEN in this workflow. Since the workflow is for building code and does not appear to need write access (e.g., it does not push commits, create releases, or manage issues/pull-requests), the safe minimal permission is `contents: read`. The best way is to add the `permissions` key at the root of the workflow YAML (before `jobs:`), which will apply to all jobs in the workflow unless overridden. No other functionality changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
