### PR TITLE
Guard the bridge lifecycle against double-start and orphaned managers

### DIFF
--- a/BridgeManager.cs
+++ b/BridgeManager.cs
@@ -85,10 +85,6 @@ public class BridgeManager : IDisposable
     /// </summary>
     public async Task StartAsync(List<DeviceInfo> devices, UserOptions userOptions, DcsBiosConfig config, CancellationToken cancellationToken = default)
     {
-        // IsLoopActive, not IsStarted: IsStarted only turns true once an aircraft has been
-        // detected, so guarding on it would leave the whole waiting phase open to a second
-        // StartAsync — which would overwrite Contexts, orphan the existing CDU contexts and
-        // open a second DCS-BIOS socket while the first loop kept running.
         if (IsLoopActive)
             throw new InvalidOperationException("Bridge is already started");
 

--- a/BridgeManager.cs
+++ b/BridgeManager.cs
@@ -85,7 +85,11 @@ public class BridgeManager : IDisposable
     /// </summary>
     public async Task StartAsync(List<DeviceInfo> devices, UserOptions userOptions, DcsBiosConfig config, CancellationToken cancellationToken = default)
     {
-        if (IsStarted)
+        // IsLoopActive, not IsStarted: IsStarted only turns true once an aircraft has been
+        // detected, so guarding on it would leave the whole waiting phase open to a second
+        // StartAsync — which would overwrite Contexts, orphan the existing CDU contexts and
+        // open a second DCS-BIOS socket while the first loop kept running.
+        if (IsLoopActive)
             throw new InvalidOperationException("Bridge is already started");
 
         if (devices == null || !devices.Any())

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -441,10 +441,6 @@ public partial class MainWindow : Window, IDisposable, INotifyPropertyChanged
 
     private async Task StartBridge()
     {
-        // This re-enters: StartBridge calls DetectDevicesAsync when nothing is connected, and
-        // DetectDevicesAsync calls back here on auto-start. The inner call's StartAsync only
-        // returns at shutdown, so without this guard the outer one would resume afterwards and
-        // build a second BridgeManager over the field. One bridge per window.
         if (IsBridgeLoopActive) return;
 
         if (!IsConfigValid())
@@ -487,9 +483,6 @@ public partial class MainWindow : Window, IDisposable, INotifyPropertyChanged
         {
             Logger.Error(ex, "Failed to start bridge");
             ShowStatus(Strings.Format("Status_FailedToStartBridgeFormat", ex.Message), true);
-            // Drop the failed manager before ResetStartButton, which reads IsBridgeLoopActive
-            // to decide whether Start becomes clickable again. Left in place it would be
-            // orphaned by the next StartBridge and keep firing its handlers into this window.
             DisposeBridgeManager();
             ResetStartButton();
         }
@@ -677,8 +670,6 @@ public partial class MainWindow : Window, IDisposable, INotifyPropertyChanged
 
     private void UpdateThemeToggleIcon()
     {
-        // ThemePreference.DCS is treated the same as Dark (folded into the default
-        // dark palette) — it can still show up here from an old persisted config.json.
         ThemeIcon.Text = _currentTheme switch
         {
             ThemePreference.Light => "☀",
@@ -695,8 +686,6 @@ public partial class MainWindow : Window, IDisposable, INotifyPropertyChanged
 
     private void LanguageToggle_Click(object sender, RoutedEventArgs e)
     {
-        // System first, then the user's own detected language, then the rest — so clicking
-        // the globe once lands on the user's language rather than a hardcoded one.
         var detected = LanguageDetector.DetectPreferredLanguage();
         var cycle = new List<LanguagePreference> { LanguagePreference.System, detected };
         cycle.AddRange(LanguageDetector.SupportedLanguages.Where(l => l != detected));
@@ -782,8 +771,6 @@ public partial class MainWindow : Window, IDisposable, INotifyPropertyChanged
 
         if (bridgeManager != null)
         {
-            // Stop() rethrows on failure, so keep disposal outside the try — otherwise a
-            // failing Stop would skip both the unsubscribe and the Dispose.
             try
             {
                 if (bridgeManager.IsLoopActive) bridgeManager.Stop();

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -441,6 +441,12 @@ public partial class MainWindow : Window, IDisposable, INotifyPropertyChanged
 
     private async Task StartBridge()
     {
+        // This re-enters: StartBridge calls DetectDevicesAsync when nothing is connected, and
+        // DetectDevicesAsync calls back here on auto-start. The inner call's StartAsync only
+        // returns at shutdown, so without this guard the outer one would resume afterwards and
+        // build a second BridgeManager over the field. One bridge per window.
+        if (IsBridgeLoopActive) return;
+
         if (!IsConfigValid())
         {
             ShowStatus(Strings.Get("Status_ConfigNotLoaded"), true);
@@ -481,8 +487,29 @@ public partial class MainWindow : Window, IDisposable, INotifyPropertyChanged
         {
             Logger.Error(ex, "Failed to start bridge");
             ShowStatus(Strings.Format("Status_FailedToStartBridgeFormat", ex.Message), true);
+            // Drop the failed manager before ResetStartButton, which reads IsBridgeLoopActive
+            // to decide whether Start becomes clickable again. Left in place it would be
+            // orphaned by the next StartBridge and keep firing its handlers into this window.
+            DisposeBridgeManager();
             ResetStartButton();
         }
+    }
+
+    /// <summary>
+    /// Detaches both event handlers from the current bridge manager, disposes it and clears
+    /// the field. Safe to call when none is present.
+    /// </summary>
+    private void DisposeBridgeManager()
+    {
+        if (bridgeManager == null) return;
+
+        bridgeManager.DetectedAircraftChanged -= OnDetectedAircraftChanged;
+        bridgeManager.DcsBiosVersionChanged -= OnDcsBiosVersionChanged;
+
+        try { bridgeManager.Dispose(); }
+        catch (Exception ex) { Logger.Error(ex, "Error disposing bridge manager"); }
+
+        bridgeManager = null;
     }
 
     private void OnDetectedAircraftChanged(string? dcsBiosName)
@@ -755,17 +782,18 @@ public partial class MainWindow : Window, IDisposable, INotifyPropertyChanged
 
         if (bridgeManager != null)
         {
+            // Stop() rethrows on failure, so keep disposal outside the try — otherwise a
+            // failing Stop would skip both the unsubscribe and the Dispose.
             try
             {
                 if (bridgeManager.IsLoopActive) bridgeManager.Stop();
-                bridgeManager.DcsBiosVersionChanged -= OnDcsBiosVersionChanged;
-                bridgeManager.Dispose();
-                bridgeManager = null;
             }
             catch (Exception ex)
             {
                 Logger.Error(ex, "Error stopping bridge during close");
             }
+
+            DisposeBridgeManager();
         }
 
         if (!_disposed)


### PR DESCRIPTION
StartAsync guarded on IsStarted, which only turns true once an aircraft has been detected — leaving the entire waiting phase open to a second start that would overwrite Contexts, orphan the existing CDU contexts and open a second DCS-BIOS socket while the first loop kept running. Guard on IsLoopActive instead.

StartBridge re-enters through DetectDevicesAsync (auto-start calls back into it), so add an IsBridgeLoopActive early return. The inner call's StartAsync only returns at shutdown, after which the outer one fell through and built a second BridgeManager over the field.

A failed start left bridgeManager non-null, undisposed and still subscribed, so the next StartBridge orphaned it while its handlers kept firing into the window. Extract DisposeBridgeManager and call it from both the failure path and close; at close it now also runs when Stop() throws, which previously skipped disposal.